### PR TITLE
add idEvent to ConsultaBoleto and fix null value in event view

### DIFF
--- a/app/src/main/java/com/example/appatemporal/domain/FirestoreService.kt
+++ b/app/src/main/java/com/example/appatemporal/domain/FirestoreService.kt
@@ -95,7 +95,7 @@ class FirestoreService {
 
     suspend fun getUserTickets(uid : String) : MutableList<GetTicketModel> {
         var result : MutableList<GetTicketModel> = arrayListOf()
-        var ticket : GetTicketModel = GetTicketModel()
+
         var boletos : QuerySnapshot =
             db.collection("Boleto")
                 .whereEqualTo("id_Usuario",uid)
@@ -112,14 +112,11 @@ class FirestoreService {
                     .whereEqualTo(FieldPath.documentId(),funciones.documents[0].data?.get("id_Evento"))
                     .get()
                     .await()
-            ticket.nombre_evento = evento.documents[0].data?.get("nombre_Evento").toString()
-            ticket.fecha = funciones.documents[0].data?.get("fecha").toString()
-            ticket.horario = funciones.documents[0].data?.get("hora_Inicio").toString()
-            ticket.lugar = evento.documents[0].data?.get("nombre_Ubicacion").toString()
-            ticket.direccion = evento.documents[0].data?.get("direccion").toString()
-            ticket.ciudad = evento.documents[0].data?.get("ciudad").toString()
-            ticket.estado = evento.documents[0].data?.get("estado").toString()
-            ticket.hash_qr = boleto.data?.get("hash_QR").toString()
+            var ticket = GetTicketModel(evento.documents[0].id, evento.documents[0].data?.get("nombre_Evento").toString(),
+                funciones.documents[0].data?.get("fecha").toString(), funciones.documents[0].data?.get("hora_Inicio").toString(),
+                evento.documents[0].data?.get("lugar").toString(), evento.documents[0].data?.get("direccion").toString(),
+                evento.documents[0].data?.get("ciudad").toString(), evento.documents[0].data?.get("estado").toString(),
+                boleto.data?.get("hash_QR").toString())
 
             result.add(ticket)
 

--- a/app/src/main/java/com/example/appatemporal/domain/models/BoletoPorEventoClass.kt
+++ b/app/src/main/java/com/example/appatemporal/domain/models/BoletoPorEventoClass.kt
@@ -1,4 +1,4 @@
-package com.example.appatemporal.framework.view
+package com.example.appatemporal.domain.models
 
 data class boletoPorEventoClass (
     var boletoTitulo: String,

--- a/app/src/main/java/com/example/appatemporal/domain/models/GetTicketModel.kt
+++ b/app/src/main/java/com/example/appatemporal/domain/models/GetTicketModel.kt
@@ -1,13 +1,14 @@
 package com.example.appatemporal.domain.models
 
 data class GetTicketModel(
-    var nombre_evento: String = "",
+    var id_evento: String,
+    var nombre_evento: String,
     //var foto_evento: String,
-    var fecha: String = "",
-    var horario: String = "",
-    var lugar: String = "",
-    var direccion: String = "",
-    var ciudad: String = "",
-    var estado: String = "",
-    var hash_qr: String = ""
+    var fecha: String,
+    var horario: String,
+    var lugar: String,
+    var direccion: String,
+    var ciudad: String,
+    var estado: String,
+    var hash_qr: String
 )

--- a/app/src/main/java/com/example/appatemporal/framework/view/ConsultarBoleto.kt
+++ b/app/src/main/java/com/example/appatemporal/framework/view/ConsultarBoleto.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.widget.ImageView
 import androidx.activity.viewModels
 import androidx.lifecycle.Observer
@@ -17,10 +18,7 @@ import com.google.zxing.BarcodeFormat
 import com.journeyapps.barcodescanner.BarcodeEncoder
 
 class ConsultarBoleto : AppCompatActivity() {
-    private val getTicketViewModel : GetUserTicketViewModel by viewModels()
     private lateinit var binding: ActivityBoletoEspectadorBinding
-    //private lateinit var binding: BoletoEspectadorActivityBinding
-    //private val repository = Repository(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,6 +43,7 @@ class ConsultarBoleto : AppCompatActivity() {
             startActivity(intent)
         }
 
+        val idEvento = intent.getStringExtra("idEvento")
         val nombre = intent.getStringExtra("nombre")
         val fecha = intent.getStringExtra("fecha")
         val hora = intent.getStringExtra("hora")
@@ -53,6 +52,8 @@ class ConsultarBoleto : AppCompatActivity() {
         val ciudad = intent.getStringExtra("ciudad")
         val estado = intent.getStringExtra("estado")
         val hashQr = intent.getStringExtra("hashQr")
+
+        Log.d("id evento seleccionado", idEvento.toString())
 
         binding.NombreEventoBoleto.text = nombre
         binding.FechaEvento.text = fecha

--- a/app/src/main/java/com/example/appatemporal/framework/view/OTPActivity.kt
+++ b/app/src/main/java/com/example/appatemporal/framework/view/OTPActivity.kt
@@ -67,10 +67,10 @@ class OTPActivity : AppCompatActivity() {
                     binding.otpProgressBar.visibility = View.VISIBLE
                     signInWithPhoneAuthCredential(credential)
                 }else{
-                    Toast.makeText( this, "Please enter coerrect OTP", Toast.LENGTH_SHORT).show()
+                    Toast.makeText( this, "Código incorrecto", Toast.LENGTH_SHORT).show()
                 }
             }else{
-                Toast.makeText( this, "Please enter OTP", Toast.LENGTH_SHORT).show()
+                Toast.makeText( this, "Ingresa el código envíado a tu celular", Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/app/src/main/java/com/example/appatemporal/framework/view/PhoneActivity.kt
+++ b/app/src/main/java/com/example/appatemporal/framework/view/PhoneActivity.kt
@@ -48,10 +48,10 @@ class PhoneActivity : AppCompatActivity() {
                     PhoneAuthProvider.verifyPhoneNumber(options)
 
                 }else{
-                    Toast.makeText(this,"Please enter correct number", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this,"Ingresa un número teléfonico válido", Toast.LENGTH_SHORT).show()
                 }
             }else{
-                Toast.makeText(this,"Please enter number", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this,"Ingresa un número telefónico", Toast.LENGTH_SHORT).show()
 
             }
         }

--- a/app/src/main/java/com/example/appatemporal/framework/view/boletosPorEventoProvider.kt
+++ b/app/src/main/java/com/example/appatemporal/framework/view/boletosPorEventoProvider.kt
@@ -1,5 +1,7 @@
 package com.example.appatemporal.framework.view
 
+import com.example.appatemporal.domain.models.boletoPorEventoClass
+
 class boletosPorEventoProvider {
     companion object {
         val proyectoList = listOf<boletoPorEventoClass>(

--- a/app/src/main/java/com/example/appatemporal/framework/view/boletosPorEventoViewHolder.kt
+++ b/app/src/main/java/com/example/appatemporal/framework/view/boletosPorEventoViewHolder.kt
@@ -38,6 +38,7 @@ class boletosPorEventoViewHolder(view: View) : RecyclerView.ViewHolder(view) {
             boletoIndividual.putExtra("ciudad", Ciudad)
             boletoIndividual.putExtra("estado", Estado)
             boletoIndividual.putExtra("hashQr", HashQR)
+            boletoIndividual.putExtra("idEvento", boletoClass.id_evento)
 
             itemView.context.startActivity(boletoIndividual)
         }


### PR DESCRIPTION
Agregué el id del evento cuando una persona consulta un evento desde la galería, y también corregí el error que aparecía en la vista de los eventos el valor de null. Lo que causaba este null es que en la consulta de firestoreService, hacían referencia al campo de "nombre_Ubicación" en una columna cuando debería ser "lugar". También para agregar el id del evento, agregué en la clase que tienen de GetTicketModel el atributo "id_evento" por lo que cada que lo se necesite utilizar este modelo recuerden también pasarle el uid del documento del evento. 

Una cosa más, al leer el GetTicketModel, este más que hacer referencia al modelo de un boleto, hace referencia a los eventos, por lo que creo que podríamos cambiar el nombre de este modelo a EventModel porque tiene el nombre del evento, lugar, fecha y todo lo demás, y ya el QR lo podrían asignar como un campo extra de este modelo.